### PR TITLE
Fix click elsewhere detection

### DIFF
--- a/src/app/click-elsewhere.directive.spec.ts
+++ b/src/app/click-elsewhere.directive.spec.ts
@@ -1,8 +1,31 @@
+import { ElementRef } from '@angular/core';
 import { ClickElsewhereDirective } from './click-elsewhere.directive';
 
 describe('ClickElsewhereDirective', () => {
   it('should create an instance', () => {
-    const directive = new ClickElsewhereDirective();
+    const directive = new ClickElsewhereDirective(new ElementRef(document.createElement('div')));
     expect(directive).toBeTruthy();
+  });
+
+  it('should emit when clicking outside host and included elements', () => {
+    const host = document.createElement('div');
+    const included = document.createElement('div');
+    const directive = new ClickElsewhereDirective(new ElementRef(host));
+    directive.includedElements = [new ElementRef(included)];
+    const spy = jasmine.createSpy('emit');
+    directive.appClickElsewhere.subscribe(spy);
+    directive.onDocumentClick({ target: document.body } as MouseEvent);
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('should not emit when clicking inside included element', () => {
+    const host = document.createElement('div');
+    const included = document.createElement('div');
+    const directive = new ClickElsewhereDirective(new ElementRef(host));
+    directive.includedElements = [new ElementRef(included)];
+    const spy = jasmine.createSpy('emit');
+    directive.appClickElsewhere.subscribe(spy);
+    directive.onDocumentClick({ target: included } as MouseEvent);
+    expect(spy).not.toHaveBeenCalled();
   });
 });

--- a/src/app/click-elsewhere.directive.ts
+++ b/src/app/click-elsewhere.directive.ts
@@ -14,17 +14,14 @@ export class ClickElsewhereDirective {
     const targetElement = event.target as HTMLElement;
 
     // Check if the click was outside the element
-    const doesNotContainElement = targetElement && !this.elementRef.nativeElement.contains(targetElement);
+    const clickOutsideHost = !!targetElement && !this.elementRef.nativeElement.contains(targetElement);
 
-    // Check if the click was outside the included elements
-    //  shortcutting so we don't look through array if we don't need to
-    const doesNotContainIncludedElements =
-      !doesNotContainElement ||
-      this.includedElements.every((elem) => {
-        return elem && !this.elementRef.nativeElement.contains(elem);
-      });
+    // If the click was outside the host, ensure it wasn't on any included element
+    const clickOutsideIncludedElements = (this.includedElements ?? []).every((elem) => {
+      return !!elem && !elem.nativeElement.contains(targetElement);
+    });
 
-    if (doesNotContainElement && doesNotContainIncludedElements) {
+    if (clickOutsideHost && clickOutsideIncludedElements) {
       this.appClickElsewhere.emit(event);
     }
   }


### PR DESCRIPTION
## Summary
- update click-elsewhere directive to properly check included elements
- add unit tests for new behaviour

## Testing
- `npx ng test --watch=false --browsers=ChromeHeadless` *(fails: request to https://registry.npmjs.org/ng failed)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of clicks outside specified elements, ensuring events are correctly emitted only when appropriate.

- **Tests**
  - Enhanced and expanded test coverage to verify correct event emission for clicks inside and outside designated elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->