### PR TITLE
Update ClickElsewhere directive tests

### DIFF
--- a/src/app/click-elsewhere.directive.spec.ts
+++ b/src/app/click-elsewhere.directive.spec.ts
@@ -1,31 +1,35 @@
 import { ElementRef } from '@angular/core';
 import { ClickElsewhereDirective } from './click-elsewhere.directive';
 
+function createMockElementRef(element: HTMLElement = document.createElement('div')): ElementRef {
+  return { nativeElement: element } as ElementRef;
+}
+
 describe('ClickElsewhereDirective', () => {
   it('should create an instance', () => {
-    const directive = new ClickElsewhereDirective(new ElementRef(document.createElement('div')));
+    const directive = new ClickElsewhereDirective(createMockElementRef());
     expect(directive).toBeTruthy();
   });
 
   it('should emit when clicking outside host and included elements', () => {
     const host = document.createElement('div');
     const included = document.createElement('div');
-    const directive = new ClickElsewhereDirective(new ElementRef(host));
-    directive.includedElements = [new ElementRef(included)];
+    const directive = new ClickElsewhereDirective(createMockElementRef(host));
+    directive.includedElements = [createMockElementRef(included)];
     const spy = jasmine.createSpy('emit');
     directive.appClickElsewhere.subscribe(spy);
-    directive.onDocumentClick({ target: document.body } as MouseEvent);
+    directive.onDocumentClick({ target: document.body } as unknown as MouseEvent);
     expect(spy).toHaveBeenCalled();
   });
 
   it('should not emit when clicking inside included element', () => {
     const host = document.createElement('div');
     const included = document.createElement('div');
-    const directive = new ClickElsewhereDirective(new ElementRef(host));
-    directive.includedElements = [new ElementRef(included)];
+    const directive = new ClickElsewhereDirective(createMockElementRef(host));
+    directive.includedElements = [createMockElementRef(included)];
     const spy = jasmine.createSpy('emit');
     directive.appClickElsewhere.subscribe(spy);
-    directive.onDocumentClick({ target: included } as MouseEvent);
+    directive.onDocumentClick({ target: included } as unknown as MouseEvent);
     expect(spy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- mock `ElementRef` in `ClickElsewhereDirective` tests
- verify the directive instance is created

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_b_68406c4cdc0c832d897c9bfac779e95a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved test setup for directive by introducing a helper function to create mock elements, ensuring more consistent and maintainable test cases. No changes to test logic or results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->